### PR TITLE
Two new features:

### DIFF
--- a/control/togglecontrol.js
+++ b/control/togglecontrol.js
@@ -13,6 +13,8 @@
  *		html {String} html to insert in the control
  *		interaction {ol.interaction} interaction associated with the control 
  *		active {bool} the control is active
+ *		defaultActive {bool} for top-level control bar, same as 'active' param above; 
+ *                           for nested control bar, sets the control active if parent control is active.
  *		onToggle {function} callback when control is clicked (or use change:active event)
  */
 ol.control.Toggle = function(options) 
@@ -40,6 +42,8 @@ ol.control.Toggle = function(options)
 	ol.control.Control.call(this, 
 	{	element: element.get(0)
 	});
+
+	this.set('defaultActive', options.defaultActive);
 
 	this.setActive (options.active);
 }


### PR DESCRIPTION
Bonjour Jean-Marc,

I've added a couple of features to ol3-ext that I needed to make use of your control bar in my mapping application, as described below. I am providing them here in case they should be of interest to you:

1) Recursively deactivate any controls in sub control bar when parent control is deactivated. When sub control bar becomes invisible because parent control has been deactivated, I need for any previously active control(s) in that sub control bar to be automatically deactivated as well.

2) New defaultActive parameter for Toggle control. For top-level control bar, same as 'active' param. For nested control bar, sets the control active when parent control is active. Handy if user typically needs to start with a specific control in a main or sub control bar.

Item (1)  seems similar to something you apparently started working on, but had commented out.

Feel free to ignore or change any of this, of course.

Once I can make controls in sub control bars change their background color when activated (issue #8), I'll be all set to go, I believe.

Thanks for a very helpful tool set.

Best,
Dennis
