### PR TITLE
setMap: Guard against `null`

### DIFF
--- a/interaction/transforminteraction.js
+++ b/interaction/transforminteraction.js
@@ -93,8 +93,10 @@ ol.interaction.Transform.prototype.setMap = function(map)
 {	if (this.getMap()) this.getMap().removeLayer(this.overlayLayer_);
 	ol.interaction.Pointer.prototype.setMap.call (this, map);
 	this.overlayLayer_.setMap(map);
-	this.isTouch = /touch/.test(map.getViewport().className);
-	this.setDefaultStyle();
+ 	if (map !== null) {
+		this.isTouch = /touch/.test(map.getViewport().className);
+		this.setDefaultStyle();
+	}
 };
 
 /**


### PR DESCRIPTION
According to the API docs, one can pass `null` to `ol.interaction.Transform`s `setMap`. But doing so will result in an error, as `/touch/.test(map.getViewport().className);` will fail.

This adds a small guard against that.
